### PR TITLE
Renaming CHANGELOG.rdoc to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,26 +1,26 @@
-== Version 0.3.1
+## Version 0.3.1
 - Warning: Minimal required Ruby version is 1.9.2 again.
 
-== Version 0.3.0
+## Version 0.3.0
 - Update: Update Correios Web Service URL.
 
-== Version 0.2.0
+## Version 0.2.0
 - Warning: Minimal required Ruby version from now is 1.9.3.
 
-== Version 0.1.4
+## Version 0.1.4
 - Improvement: Minimal required Ruby version now is 1.9.2.
 
-== Version 0.1.3
+## Version 0.1.3
 - Improvement: Update LogMe gem to version 0.0.6 with support to log request and response messages.
 
-== Version 0.1.2
+## Version 0.1.2
 - Improvement: Update LogMe gem to version 0.0.5 with support to log messages label.
 
-== Version 0.1.1
+## Version 0.1.1
 - New: A "get" class method in AddressFinder class.
 
-== Version 0.1.0
+## Version 0.1.0
 - First working version.
 
-== Version 0.0.1
+## Version 0.0.1
 - First version, not working yet.


### PR DESCRIPTION
These changes provide a better view of the CHANGELOG file on GitHub and others applications.