### PR TITLE
Melhora forma como erros são lançados

### DIFF
--- a/correios-cep.gemspec
+++ b/correios-cep.gemspec
@@ -20,13 +20,13 @@ Gem::Specification.new do |spec|
   spec.platform              = Gem::Platform::RUBY
   spec.required_ruby_version = Gem::Requirement.new('>= 1.9.2')
 
-  spec.add_dependency 'log-me',   '= 0.0.8'
-  spec.add_dependency "ox", "~> 2.2"
+  spec.add_dependency "log-me",   "= 0.0.8"
+  spec.add_dependency "ox",       "~> 2.2"
 
-  spec.add_development_dependency "coveralls"
-  spec.add_development_dependency "pry"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec",   "~> 3.2"
-  spec.add_development_dependency "vcr",     "~> 2.9"
-  spec.add_development_dependency "webmock", "~> 1.15"
+  spec.add_development_dependency "coveralls", "~> 0.8.3"
+  spec.add_development_dependency "pry",       "~> 0.10.3"
+  spec.add_development_dependency "rake",      "~> 10.4", ">= 10.4.2"
+  spec.add_development_dependency "rspec",     "~> 3.2"
+  spec.add_development_dependency "vcr",       "~> 2.9"
+  spec.add_development_dependency "webmock",   "~> 1.15"
 end

--- a/lib/correios/cep/address_finder.rb
+++ b/lib/correios/cep/address_finder.rb
@@ -28,11 +28,11 @@ module Correios
       def format_response(response)
         case response
         when "CEP NAO ENCONTRADO" 
-          raise CEPNotFound.new
+          raise CEPNotFound.new "" 
         when "BUSCA DEFINIDA COMO EXATA, 0 CEP DEVE TER 8 DIGITOS" 
-          raise InvalidCEPFormat.new
+          raise InvalidCEPFormat.new "" 
         when "CEP NAO INFORMADO"
-          raise CEPNotFound.new
+          raise CEPNotFound.new "" 
         else
           response
         end

--- a/lib/correios/cep/address_finder.rb
+++ b/lib/correios/cep/address_finder.rb
@@ -1,9 +1,12 @@
 module Correios
   module CEP
     class AddressFinder
+      class CEPNotFound < RuntimeError ; end;
+      class InvalidCEPFormat < RuntimeError ; end;
+
       def get(zipcode)
         response = web_service.request(zipcode)
-        parser.address(response)
+        format_response parser.address(response)
       end
 
       def self.get(zipcode)
@@ -18,6 +21,21 @@ module Correios
 
       def parser
         @parser ||= Correios::CEP::Parser.new
+      end
+
+      private
+
+      def format_response(response)
+        case response
+        when "CEP NAO ENCONTRADO" 
+          raise CEPNotFound.new
+        when "BUSCA DEFINIDA COMO EXATA, 0 CEP DEVE TER 8 DIGITOS" 
+          raise InvalidCEPFormat.new
+        when "CEP NAO INFORMADO"
+          raise CEPNotFound.new
+        else
+          response
+        end
       end
     end
   end

--- a/lib/correios/cep/parser.rb
+++ b/lib/correios/cep/parser.rb
@@ -15,6 +15,10 @@ module Correios
 
       def address(xml)
         doc = Ox.parse(xml)
+        
+        errors = get_errors(doc)
+        return errors unless errors.nil?
+
         return_node = find_node(doc.nodes, 'return')
         return if return_node.nil?
 
@@ -29,11 +33,25 @@ module Correios
 
       private
 
+      def get_errors(doc)
+        error_node = find_node(doc.nodes, 'detail')
+        return find_value(error_node.nodes) unless error_node.nil?
+        nil
+      end
+
       def find_node(nodes, name)
-        node = nodes.first
+        node = nodes.last
+        return nil unless node.is_a?(Ox::Element)
         return node if node.nil? || node.name == name
 
         find_node(node.nodes, name)
+      end
+
+      def find_value(nodes)
+        node = nodes.last
+        return node unless node.is_a?(Ox::Element)
+
+        find_value(node.nodes)
       end
 
       def text_for(element)

--- a/spec/correios/cep/address_finder_spec.rb
+++ b/spec/correios/cep/address_finder_spec.rb
@@ -1,24 +1,48 @@
 require 'spec_helper'
 
 describe Correios::CEP::AddressFinder do
-  let(:cep) { '54250610' }
-  let(:web_service_response) { '<end>Rua Fernando Amorim</end>' }
-  let(:address) { { address: 'Rua Fernando Amorim' } }
 
-  before do
-    allow_any_instance_of(Correios::CEP::WebService).to receive(:request).with(cep).and_return(web_service_response)
-    allow_any_instance_of(Correios::CEP::Parser).to receive(:address).with(web_service_response).and_return(address)
-  end
+  context "when address is valid" do
+    let(:cep) { '54250610' }
+    let(:web_service_response) { '<end>Rua Fernando Amorim</end>' }
+    let(:address) { { address: 'Rua Fernando Amorim' } }
 
-  describe '#get' do
-    it 'returns address' do
-      expect(subject.get(cep)).to eql address
+    before do
+      allow_any_instance_of(Correios::CEP::WebService).to receive(:request).with(cep){ web_service_response }
+      allow_any_instance_of(Correios::CEP::Parser).to receive(:address).with(web_service_response){ address }
+    end
+
+    describe '#get' do
+      it 'returns address' do
+        expect(subject.get(cep)).to eql address
+      end
+    end
+
+    describe '.get' do
+      it 'returns address' do
+        expect(Correios::CEP::AddressFinder.get(cep)).to eql address
+      end
     end
   end
 
-  describe '.get' do
-    it 'returns address' do
-      expect(Correios::CEP::AddressFinder.get(cep)).to eql address
+  context "when address is not valid" do
+    before do
+      allow_any_instance_of(Correios::CEP::WebService).to receive(:request)
+    end
+
+    it "raises CEPNotFound when cep is empty" do
+      allow_any_instance_of(Correios::CEP::Parser).to receive(:address){ "CEP NAO INFORMADO" }
+      expect{ subject.get("") }.to raise_error(Correios::CEP::AddressFinder::CEPNotFound)
+    end
+
+    it "raises CEPNotFound when cep was not found" do
+      allow_any_instance_of(Correios::CEP::Parser).to receive(:address){ "CEP NAO ENCONTRADO" }
+      expect{ subject.get("") }.to raise_error(Correios::CEP::AddressFinder::CEPNotFound)
+    end
+
+    it "raises InvalidCEPFormat when cep has invalid format" do
+      allow_any_instance_of(Correios::CEP::Parser).to receive(:address){ "BUSCA DEFINIDA COMO EXATA, 0 CEP DEVE TER 8 DIGITOS" }
+      expect{ subject.get("") }.to raise_error(Correios::CEP::AddressFinder::InvalidCEPFormat)
     end
   end
 end

--- a/spec/correios/cep/parser_spec.rb
+++ b/spec/correios/cep/parser_spec.rb
@@ -2,20 +2,20 @@
 require 'spec_helper'
 
 describe Correios::CEP::Parser do
-  describe '#address' do
+  describe "#address" do
     let(:expected_address) do
       {
-        address: 'Rua Fernando Amorim',
-        neighborhood: 'Cavaleiro',
-        city: 'Jaboatão dos Guararapes',
-        state: 'PE',
-        zipcode: '54250610',
-        complement: ''
+        address: "Rua Fernando Amorim",
+        neighborhood: "Cavaleiro",
+        city: "Jaboatão dos Guararapes",
+        state: "PE",
+        zipcode: "54250610",
+        complement: ""
       }
     end
 
-    context 'when address is found' do
-      context 'and does not have complement' do
+    context "when address is found" do
+      context "and does not have complement" do
         let(:xml) do
           "<?xml version='1.0' encoding='UTF-8'?>" +
           "<S:Envelope>" +
@@ -36,7 +36,7 @@ describe Correios::CEP::Parser do
           "</S:Envelope>"
         end
 
-        it 'returns address' do
+        it "returns address" do
           expect(subject.address(xml)).to eq expected_address
         end
       end
@@ -62,8 +62,8 @@ describe Correios::CEP::Parser do
           "</S:Envelope>"
         end
 
-        it 'returns address' do
-          expected_address[:complement] = 'de 1500 até o fim'
+        it "returns address" do
+          expected_address[:complement] = "de 1500 até o fim"
 
           expect(subject.address(xml)).to eq expected_address
         end
@@ -90,8 +90,8 @@ describe Correios::CEP::Parser do
           "</S:Envelope>"
         end
 
-        it 'returns address' do
-          expected_address[:complement] = 'de 1500 até o fim (zona mista)'
+        it "returns address" do
+          expected_address[:complement] = "de 1500 até o fim (zona mista)"
 
           expect(subject.address(xml)).to eq expected_address
         end
@@ -108,8 +108,74 @@ describe Correios::CEP::Parser do
         "</S:Envelope>"
       end
 
-      it 'returns nil' do
+      it "returns nil" do
         expect(subject.address(xml)).to be_nil
+      end
+    end
+
+    context "when cep has invalid format" do
+      let(:xml) do
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+          "<soap:Body>" +
+            "<soap:Fault>" +
+              "<faultcode>soap:Server</faultcode>" +
+              "<faultstring>BUSCA DEFINIDA COMO EXATA, 0 CEP DEVE TER 8 DIGITOS</faultstring>" +
+              "<detail>" +
+                "<ns2:SigepClienteException xmlns:ns2=\"http://cliente.bean.master.sigep.bsb.correios.com.br/\">" +
+                  "BUSCA DEFINIDA COMO EXATA, 0 CEP DEVE TER 8 DIGITOS" +
+                "</ns2:SigepClienteException>" +
+              "</detail>" +
+            "</soap:Fault>" +
+          "</soap:Body>" +
+        "</soap:Envelope>"
+      end
+
+      it "returns message of invalid format" do
+        expect(subject.address(xml)).to eq("BUSCA DEFINIDA COMO EXATA, 0 CEP DEVE TER 8 DIGITOS")
+      end
+    end
+
+    context "when cep was not nound" do
+      let(:xml) do
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+          "<soap:Body>" +
+            "<soap:Fault>" +
+              "<faultcode>soap:Server</faultcode>" +
+              "<faultstring>CEP NAO ENCONTRADO</faultstring>" +
+              "<detail>" +
+                "<ns2:SigepClienteException xmlns:ns2=\"http://cliente.bean.master.sigep.bsb.correios.com.br/\">" +
+                  "CEP NAO ENCONTRADO" +
+                "</ns2:SigepClienteException>" +
+              "</detail>" +
+            "</soap:Fault>" +
+          "</soap:Body>" +
+        "</soap:Envelope>"
+      end
+
+      it "returns message of not found" do
+        expect(subject.address(xml)).to eq("CEP NAO ENCONTRADO")
+      end
+    end
+
+    context "when cep is empty" do
+      let(:xml) do
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">" +
+          "<soap:Body>" +
+            "<soap:Fault>" +
+              "<faultcode>soap:Server</faultcode>" +
+              "<faultstring>CEP NAO INFORMADO</faultstring>" +
+              "<detail>" +
+                "<ns2:SigepClienteException xmlns:ns2=\"http://cliente.bean.master.sigep.bsb.correios.com.br/\">" +
+                  "CEP NAO INFORMADO" +
+                "</ns2:SigepClienteException>" +
+              "</detail>" +
+            "</soap:Fault>" +
+          "</soap:Body>" +
+        "</soap:Envelope>"
+      end
+
+      it "returns message of empty cep" do
+        expect(subject.address(xml)).to eq("CEP NAO INFORMADO")
       end
     end
   end


### PR DESCRIPTION
Melhorias:

* Lança a exceção CEPNotFound quando o cep não foi encontrado ou não foi informado.
* Lança a exceção InvalidCEPFormat quando o formato do cep é inválido
* Adiciona versão das dependências para prevenir warnings ao fazer o build da gem