### PR TITLE
Add a simple retry mechanism to WebService

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,15 @@ Correios::CEP.configure do |config|
 end
 ```
 
+### Max retries
+
+Since Correios is not that reliable you may want to retry failed requests. The maximum number of attempts (replays of the original request) after a failed requests can be configured as the following snippet:
+
+```ruby
+Correios::CEP.configure do |config|
+  config.max_retries = 3
+end
+
 ### Log
 
 For default, each request to Correios Web service is logged to STDOUT, with **:info** log level, using the gem [LogMe](http://github.com/prodis/log-me).

--- a/lib/correios/cep/config.rb
+++ b/lib/correios/cep/config.rb
@@ -2,7 +2,8 @@ module Correios
   module CEP
     module Config
       DEFAULT_REQUEST_TIMEOUT = 5 #seconds
-      attr_writer :proxy_url, :request_timeout
+      DEFAULT_MAX_RETRIES = 3
+      attr_writer :proxy_url, :request_timeout, :max_retries
 
       def proxy_url
         @proxy_url ||= ''
@@ -10,6 +11,10 @@ module Correios
 
       def request_timeout
         (@request_timeout ||= DEFAULT_REQUEST_TIMEOUT).to_i
+      end
+
+      def max_retries
+        @max_retries ||= DEFAULT_MAX_RETRIES
       end
     end
   end

--- a/lib/correios/cep/web_service.rb
+++ b/lib/correios/cep/web_service.rb
@@ -67,7 +67,7 @@ module Correios
         Correios::CEP.log_response(response)
         response
       rescue EOFError
-        retry if (retries += 1) < 3 || raise
+        retry if (retries += 1) < Correios::CEP.max_retries || raise
       end
     end
   end

--- a/spec/correios/cep/web_service_spec.rb
+++ b/spec/correios/cep/web_service_spec.rb
@@ -10,9 +10,32 @@ describe Correios::CEP::WebService do
       Correios::CEP.log_enabled = true
     end
 
-    it 'returns HTTP response body from Correios web service' do
-      result = subject.request(cep)
-      expect(result).to include('Rua Fernando Amorim')
+    context 'when Correios response is successful' do
+      it 'returns HTTP response body from Correios web service' do
+        result = subject.request(cep)
+        expect(result).to include('Rua Fernando Amorim')
+      end
+    end
+  end
+
+  describe '#request without VCR' do
+    before { VCR.turn_off! }
+    after { VCR.turn_on! }
+
+    around do |example|
+      Correios::CEP.log_enabled = false
+      example.run
+      Correios::CEP.log_enabled = true
+    end
+
+    context 'when Correios drop packets' do
+      it 'throws an exception after 3 retries' do
+        stub_request(:post, /apps.correios.com.br/).to_raise(EOFError)
+                                                   .then.to_raise(EOFError)
+                                                   .then.to_raise(EOFError)
+
+        expect { subject.request(cep) }.to raise_error(EOFError)
+      end
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require 'correios-cep'
 require 'coveralls'
 require 'vcr'
+require 'webmock/rspec'
 
 Coveralls.wear!
 
@@ -12,8 +13,11 @@ RSpec.configure do |config|
 end
 
 VCR.configure do |config|
+  config.allow_http_connections_when_no_cassette = true
   config.default_cassette_options = { :match_requests_on => [:uri, :method, :body] }
   config.cassette_library_dir = 'spec/fixtures/cassettes'
   config.hook_into :webmock
   config.configure_rspec_metadata!
 end
+
+WebMock.disable_net_connect!


### PR DESCRIPTION
Correios occasionally cannot handle a request and drop a packet which is one of the causes of the `EOFError` thrown by Ruby's OpenSSL. The idea is retry the request 3 times and get a response from Correios otherwise re-raise the `EOFError`.