### PR TITLE
upgrade ox gem

### DIFF
--- a/correios-cep.gemspec
+++ b/correios-cep.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
 
   spec.add_dependency 'log-me', '~> 0.0.10'
-  spec.add_dependency 'ox',     '~> 2.2.2'
+  spec.add_dependency 'ox',     '~> 2.4'
 
   spec.add_development_dependency 'coveralls', '~> 0.8.10'
   spec.add_development_dependency 'pry',       '~> 0.10.3'


### PR DESCRIPTION
apparently ox version 2.2.4 has a bug and won't let me upgrade it.

upgrading it worked for me. specs are still green.

```rb
➜  project git:(master) ✗ ruby -v
ruby 2.4.0p0 (2016-12-24 revision 57164) [x86_64-darwin16]
➜  project git:(master) ✗ bundle -v
Bundler version 1.14.6
```

```rb
$ bundle install

[...]
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

current directory:
/Users/rafa/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ox-2.2.4/ext/ox
/Users/rafa/.rbenv/versions/2.4.0/bin/ruby -r
./siteconf20170317-89146-1ibjse8.rb extconf.rb
>>>>> Creating Makefile for ruby version 2.4.0 on x86_64-darwin16 <<<<<
creating Makefile

current directory:
/Users/rafa/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ox-2.2.4/ext/ox
make "DESTDIR=" clean

current directory:
/Users/rafa/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ox-2.2.4/ext/ox
make "DESTDIR="
compiling base64.c
compiling cache.c
compiling cache8.c
compiling cache8_test.c
compiling cache_test.c
compiling dump.c
dump.c:752:18: warning: 'rb_struct_ptr' is deprecated
[-Wdeprecated-declarations]
            VALUE       beg = RSTRUCT_PTR(obj)[0];
                              ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/ruby.h:1190:33:
note: expanded from macro 'RSTRUCT_PTR'
                                ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/intern.h:889:25:
note: 'rb_struct_ptr' has been explicitly marked deprecated here
DEPRECATED(const VALUE *rb_struct_ptr(VALUE s));
                        ^
dump.c:753:18: warning: 'rb_struct_ptr' is deprecated
[-Wdeprecated-declarations]
            VALUE       end = RSTRUCT_PTR(obj)[1];
                              ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/ruby.h:1190:33:
note: expanded from macro 'RSTRUCT_PTR'
                                ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/intern.h:889:25:
note: 'rb_struct_ptr' has been explicitly marked deprecated here
DEPRECATED(const VALUE *rb_struct_ptr(VALUE s));
                        ^
dump.c:754:19: warning: 'rb_struct_ptr' is deprecated
[-Wdeprecated-declarations]
            VALUE       excl = RSTRUCT_PTR(obj)[2];
                               ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/ruby.h:1190:33:
note: expanded from macro 'RSTRUCT_PTR'
                                ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/intern.h:889:25:
note: 'rb_struct_ptr' has been explicitly marked deprecated here
DEPRECATED(const VALUE *rb_struct_ptr(VALUE s));
                        ^
dump.c:774:23: warning: 'rb_struct_ptr' is deprecated
[-Wdeprecated-declarations]
            for (i = 0, vp = RSTRUCT_PTR(obj); i < cnt; i++, vp++) {
                             ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/ruby.h:1190:33:
note: expanded from macro 'RSTRUCT_PTR'
                                ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/intern.h:889:25:
note: 'rb_struct_ptr' has been explicitly marked deprecated here
DEPRECATED(const VALUE *rb_struct_ptr(VALUE s));
                        ^
dump.c:774:21: warning: assigning to 'VALUE *' (aka 'unsigned long *')
from
'const VALUE *' (aka 'const unsigned long *') discards qualifiers
[-Wincompatible-pointer-types-discards-qualifiers]
            for (i = 0, vp = RSTRUCT_PTR(obj); i < cnt; i++, vp++) {
                           ^ ~~~~~~~~~~~~~~~~
5 warnings generated.
compiling err.c
compiling gen_load.c
compiling obj_load.c
obj_load.c:759:7: warning: 'rb_struct_ptr' is deprecated
[-Wdeprecated-declarations]
                    RSTRUCT_PTR(ph->obj)[0] = h->obj;
                    ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/ruby.h:1190:33:
note: expanded from macro 'RSTRUCT_PTR'
                                ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/intern.h:889:25:
note: 'rb_struct_ptr' has been explicitly marked deprecated here
DEPRECATED(const VALUE *rb_struct_ptr(VALUE s));
                        ^
obj_load.c:759:31: error: read-only variable is not assignable
                    RSTRUCT_PTR(ph->obj)[0] = h->obj;
                    ~~~~~~~~~~~~~~~~~~~~~~~ ^
obj_load.c:761:7: warning: 'rb_struct_ptr' is deprecated
[-Wdeprecated-declarations]
                    RSTRUCT_PTR(ph->obj)[1] = h->obj;
                    ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/ruby.h:1190:33:
note: expanded from macro 'RSTRUCT_PTR'
                                ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/intern.h:889:25:
note: 'rb_struct_ptr' has been explicitly marked deprecated here
DEPRECATED(const VALUE *rb_struct_ptr(VALUE s));
                        ^
obj_load.c:761:31: error: read-only variable is not assignable
                    RSTRUCT_PTR(ph->obj)[1] = h->obj;
                    ~~~~~~~~~~~~~~~~~~~~~~~ ^
obj_load.c:763:7: warning: 'rb_struct_ptr' is deprecated
[-Wdeprecated-declarations]
                    RSTRUCT_PTR(ph->obj)[2] = h->obj;
                    ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/ruby.h:1190:33:
note: expanded from macro 'RSTRUCT_PTR'
                                ^
/Users/rafa/.rbenv/versions/2.4.0/include/ruby-2.4.0/ruby/intern.h:889:25:
note: 'rb_struct_ptr' has been explicitly marked deprecated here
DEPRECATED(const VALUE *rb_struct_ptr(VALUE s));
                        ^
obj_load.c:763:31: error: read-only variable is not assignable
                    RSTRUCT_PTR(ph->obj)[2] = h->obj;
                    ~~~~~~~~~~~~~~~~~~~~~~~ ^
3 warnings and 3 errors generated.
make: *** [obj_load.o] Error 1

make failed, exit code 2

Gem files will remain installed in
/Users/rafa/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/gems/ox-2.2.4 for
inspection.
Results logged to
/Users/rafa/.rbenv/versions/2.4.0/lib/ruby/gems/2.4.0/extensions/x86_64-darwin-16/2.4.0-static/ox-2.2.4/gem_make.out

An error occurred while installing ox (2.2.4), and Bundler cannot
continue.
Make sure that `gem install ox -v '2.2.4'` succeeds before bundling.
```