### PR TITLE
Fixed ox gem security update

### DIFF
--- a/correios-cep.gemspec
+++ b/correios-cep.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = Gem::Requirement.new('>= 2.0.0')
 
   spec.add_dependency 'log-me', '~> 0.0.10'
-  spec.add_dependency 'ox',     '~> 2.4', '>= 2.4.13'
+  spec.add_dependency 'ox', '~> 2.8', '>= 2.8.2'
 
   spec.add_development_dependency 'coveralls', '~> 0.8.20'
   spec.add_development_dependency 'pry',       '~> 0.10'

--- a/lib/correios/cep/version.rb
+++ b/lib/correios/cep/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Correios
   module CEP
-    VERSION = '0.6.4'
+    VERSION = '0.6.5'
   end
 end

--- a/lib/correios/cep/version.rb
+++ b/lib/correios/cep/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module Correios
   module CEP
-    VERSION = '0.6.5'
+    VERSION = '0.6.4'
   end
 end


### PR DESCRIPTION
Hi guys,

It's fixes a gap in `ox gem` security fixed in this week.
In which it was possible to explode the memory of the parser. The same made that gem vulnerable.

Yeah :feet: :tada: 