### PR TITLE
Adicionado correção para quando não existe "complemento" na resposta do Correios

### DIFF
--- a/lib/correios/cep/parser.rb
+++ b/lib/correios/cep/parser.rb
@@ -43,6 +43,7 @@ module Correios
       end
 
       def join_complements(address)
+        address[:complement] = "" if address[:complement].nil?
         address[:complement] += " #{address.delete(:complement2)}"
         address[:complement].strip!
       end


### PR DESCRIPTION
Criar o complemento para evitar erro no Parser.
Correios não está enviando mais o campo "complemento", o que causa erro nas funções do Parser.