### PR TITLE
 Suitable for using the gem with the rails version 6

### DIFF
--- a/lib/correios/cep/parser.rb
+++ b/lib/correios/cep/parser.rb
@@ -40,7 +40,7 @@ module Correios
       end
 
       def text_for(element)
-        element.text.to_s.force_encoding(Encoding::UTF_8)
+        element.text.to_s.dub.force_encoding(Encoding::UTF_8)
       end
 
       def join_complements(address)

--- a/lib/correios/cep/parser.rb
+++ b/lib/correios/cep/parser.rb
@@ -40,7 +40,7 @@ module Correios
       end
 
       def text_for(element)
-        element.text.to_s.dub.force_encoding(Encoding::UTF_8)
+        element.text.to_s.dup.force_encoding(Encoding::UTF_8)
       end
 
       def join_complements(address)


### PR DESCRIPTION
I added the dup in front of the force encoding to eliminate the error when using rails in version 6.