### PR TITLE
Fix error force encoding

### DIFF
--- a/lib/correios/cep/parser.rb
+++ b/lib/correios/cep/parser.rb
@@ -42,7 +42,7 @@ module Correios
       end
 
       def text_for(element)
-        element.text.nil? ? "" : element.text.force_encoding(Encoding::UTF_8)
+        element.text.nil? ? "" : element.text.dup.force_encoding(Encoding::UTF_8)
       end
 
       def join_complements(address)


### PR DESCRIPTION
I added the dup to fix the error in force encoding for using rails 6